### PR TITLE
OCPBUGS-83863: Strip debug symbols from Go binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,5 +16,6 @@ CMDS=livenessprobe
 all: build
 
 include release-tools/build.make
+LDFLAGS = -s -w
 
 test: test-logcheck


### PR DESCRIPTION
## Summary
- Set `LDFLAGS = -s -w` in `Makefile` after including `release-tools/build.make` to strip DWARF debug info and symbol tables

## Impact
The csi-livenessprobe image (310 MB) contains one unstripped Go binary:
- `livenessprobe` (26.9 MB)

Stripping typically reduces Go binary size by 20-30%, reducing container image pull time during node scale-up.

## Test plan
- [ ] Verify image builds successfully
- [ ] Verify binary is stripped
- [ ] Verify livenessprobe functions correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build configuration for improved executable efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->